### PR TITLE
Sc0tts/temperatures units are celsius

### DIFF
--- a/cmip/cmip_model.py
+++ b/cmip/cmip_model.py
@@ -476,7 +476,6 @@ class CMIPComponentMethod(object):
             return
 
         # If the year is new, set the data from the file
-        #filename = self.get_current_ncdata_filename(thisdate)
         self.set_dataset_arrays(thisdate)
 
 

--- a/cmip/cmip_model.py
+++ b/cmip/cmip_model.py
@@ -458,6 +458,10 @@ class CMIPComponentMethod(object):
         thisdate = dt.date(year, month, 1)
         self.ensure_temperatures(thisdate)
 
+        # Note: the netcdf file Temperature units are Kelvin, but this
+        #       component's units are Celsius.  Convert here.
+        self._temperature = np.subtract(self._temperature, 273.15)
+
         if (thisdate < self._first_valid_date) or \
            (thisdate > self._last_valid_date):
             print('Warning: date has no associated datafile')

--- a/cmip/cmip_model.py
+++ b/cmip/cmip_model.py
@@ -7,7 +7,7 @@ files processed by Yassin at NSIDC
 """
 from  __future__ import print_function
 
-import calendar
+#import calendar
 import datetime as dt
 import os
 import yaml
@@ -70,6 +70,13 @@ class CMIPComponentMethod(object):
         # Month day for 'canonical' date-of-year
         self.month = 12
         self.day = 15
+
+        # Initialize these values to None
+        self.filepattern = None
+        self.srcdata_dir = None
+        self.T_air_jan = None
+        self.T_air_jul = None
+        self.temperature_year = None
 
 
     def get_current_ncdata_filename(self, thisdate, srcdir=None,
@@ -186,7 +193,7 @@ class CMIPComponentMethod(object):
         # routine for each type of grid
         try:
             exec_cmd = 'self.verify_config_for_{}_run(cfg_struct)'.format(
-                 cfg_struct['grid_type'])
+                cfg_struct['grid_type'])
             exec(exec_cmd)
         except:
             raise
@@ -341,7 +348,7 @@ class CMIPComponentMethod(object):
 
 
     def set_temperature_arrays(self, thisdate):
-        # Set the dat aarray sfrom the dataset arrays
+        # Set the data arrays from the dataset arrays
         self.T_air = self.get_temperature_month_year(thisdate.month,
                                                      thisdate.year)
         self.T_air_jan = self.get_temperature_month_year(1, thisdate.year)
@@ -451,8 +458,6 @@ class CMIPComponentMethod(object):
         thisdate = dt.date(year, month, 1)
         self.ensure_temperatures(thisdate)
 
-        filename = self.get_current_ncdata_filename(thisdate)
-
         if (thisdate < self._first_valid_date) or \
            (thisdate > self._last_valid_date):
             print('Warning: date has no associated datafile')
@@ -471,7 +476,9 @@ class CMIPComponentMethod(object):
             return
 
         # If the year is new, set the data from the file
-        filename = self.get_current_ncdata_filename(thisdate)
+        #filename = self.get_current_ncdata_filename(thisdate)
+        self.set_dataset_arrays(thisdate)
+
 
 
     def update_temperature_values(self):

--- a/cmip/tests/test_bmi_cmip.py
+++ b/cmip/tests/test_bmi_cmip.py
@@ -6,7 +6,7 @@ test_bmi_cmip.py
 import datetime
 import os
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_not_equal
 
 import cmip
 from cmip.tests import examples_directory
@@ -22,11 +22,13 @@ def test_cmip_has_initialize():
     ct = cmip.bmi_cmip.BmiCMIPComponentMethod()
     ct.initialize(cfg_file=default_config_filename)
 
+
 def test_initialize_sets_times():
     # Can we call an initialize function?
     ct = cmip.bmi_cmip.BmiCMIPComponentMethod()
     ct.initialize(cfg_file=default_config_filename)
     assert_equal(ct._model.first_date, datetime.date(1902, 12, 15))
+
 
 def test_att_map():
     ct = cmip.bmi_cmip.BmiCMIPComponentMethod()
@@ -34,12 +36,14 @@ def test_att_map():
     assert_equal('PermaModel_CMIPComponent', ct.get_attribute('model_name'))
     assert_equal('days', ct.get_attribute('time_units'))
 
+
 def test_get_input_var_names():
     ct = cmip.bmi_cmip.BmiCMIPComponentMethod()
     ct.initialize(cfg_file=default_config_filename)
     input_vars = ct.get_input_var_names()
     # no input variables for cmip
     assert_equal(0, len(input_vars))
+
 
 def test_get_output_var_names():
     ct = cmip.bmi_cmip.BmiCMIPComponentMethod()
@@ -54,6 +58,7 @@ def test_get_output_var_names():
     #               'datetime__end')
     assert_equal(output_vars, output_list)
 
+
 def test_get_var_name():
     ct = cmip.bmi_cmip.BmiCMIPComponentMethod()
     ct.initialize(cfg_file=default_config_filename)
@@ -63,3 +68,32 @@ def test_get_var_name():
         ct.get_var_name('atmosphere_bottom_air__temperature_mean_jul')
     assert_equal(this_var_name, 'T_air_jul')
 
+
+def test_update_changes_temperature():
+    b0 = cmip.bmi_cmip.BmiCMIPComponentMethod()
+
+    b0.initialize(cfg_file=default_config_filename)
+
+    index_flat = 50
+    index2D = (10, 5)
+
+    Tb0_2d_0 = b0.get_value(
+        'atmosphere_bottom_air__temperature')[index2D]
+    Tb0_flat_0 = b0.get_value(
+        'atmosphere_bottom_air__temperature').flatten()[index_flat]
+
+    Tb0_2d_last = 0.0
+    Tb0_flat_last = 0.0
+    for i in range(1, 11):
+        b0.update()
+
+        Tb0_2d = b0.get_value(
+            'atmosphere_bottom_air__temperature')[index2D]
+        Tb0_flat = b0.get_value(
+            'atmosphere_bottom_air__temperature').flatten()[index_flat]
+
+        assert_not_equal(Tb0_2d_last, Tb0_2d)
+        assert_not_equal(Tb0_flat_last, Tb0_flat)
+
+        Tb0_2d_last = Tb0_2d
+        Tb0_flat_last = Tb0_flat

--- a/cmip/tests/test_cmip.py
+++ b/cmip/tests/test_cmip.py
@@ -6,7 +6,7 @@ test_cmip.py
 import datetime
 import numpy as np
 from dateutil.relativedelta import relativedelta
-from nose.tools import (assert_almost_equal, assert_equal)
+from nose.tools import assert_almost_equal, assert_equal, assert_true
 import cmip
 import os
 
@@ -114,15 +114,15 @@ def test_specific_netcdf_values():
     t_idx = 0
     x_idx = 11
     y_idx = 0
-    #assert_almost_equal(ct._temperature[t_idx, y_idx, x_idx], 259.1304, places=2)
+    # Temperature units for this model are Celsius
     assert_almost_equal(
-        ct._temperature[t_idx, y_idx, x_idx], 260.1971, places=2)
+        ct._temperature[t_idx, y_idx, x_idx], 260.1971 - 273.15, places=2)
 
     t_idx = 0
     x_idx = 3
     y_idx = 18
     assert_almost_equal(
-        ct._temperature[t_idx, y_idx, x_idx], 252.3327, places=2)
+        ct._temperature[t_idx, y_idx, x_idx], 252.3327 - 273.15, places=2)
 
 
 def test_getting_monthly_annual_temp_values():
@@ -133,13 +133,15 @@ def test_getting_monthly_annual_temp_values():
 
     x_idx = 2
     y_idx = 1
-    assert_almost_equal(ct.T_air_annual_mean[y_idx, x_idx], 271.7334, places=2)
+    assert_almost_equal(ct.T_air_annual_mean[y_idx, x_idx],
+                        271.7334 - 273.15, places=2)
 
     t_idx = 6
     x_idx = 19
     y_idx = 3
     jul_temperatures = ct.get_temperature_month_year(7, 1902)
-    assert_almost_equal(jul_temperatures[y_idx, x_idx], 287.3322, places=2)
+    assert_almost_equal(jul_temperatures[y_idx, x_idx],
+                        287.3322 - 273.15, places=2)
 
 
 def test_can_increment_to_end_of_run():
@@ -202,3 +204,18 @@ def test_can_get_subarray_for_date():
     # This should be from the 'testing' or 'examples' or 'data' directory?
     expected_temperature_array = \
         np.fromfile(test_temp_field_file, dtype=np.float32)
+
+def test_temperature_units_are_Celsius():
+    """ test that temperature values are not Kelvin """
+    ct = cmip.cmip_model.CMIPComponentMethod()
+    ct.initialize_from_config_file()
+
+    x_idx = 2
+    y_idx = 1
+    assert_true(np.abs(ct.T_air_annual_mean[y_idx, x_idx]) < 50.0)
+
+    t_idx = 6
+    x_idx = 19
+    y_idx = 3
+    jul_temperatures = ct.get_temperature_month_year(7, 1902)
+    assert_true(np.abs(jul_temperatures[y_idx, x_idx]) < 50.0)


### PR DESCRIPTION
Added a test to show that temperatures were not within 50 degrees of 0 degrees Celsius.

Subtract 273.15 degrees from the values from the netcdf file to convert from Kelvin to Celsius.

Corrected previous test of specific values from the netcdf file.

Note: this pull request also includes the fix for the timestep-not-updating issue