### PR TITLE
flip the temperature arrays along the y-axis

### DIFF
--- a/cmip/cmip_model.py
+++ b/cmip/cmip_model.py
@@ -376,10 +376,19 @@ class CMIPComponentMethod(object):
         # the best way to read from files that are several GB in size
         nc_temperature = self._temperature_nc_dataset.variables['TS']
 
-        # Sets the onthly array of gridded values
-        self._temperature = np.asarray(nc_temperature[
-            :, self._nc_j0:self._nc_j1:self._nc_jskip,
-            self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
+        # Sets the monthly array of gridded values
+        # Note: netcdf values are "flipped" in the y-axis, so they will be
+        # corrected here
+        temp_array = np.asarray(nc_temperature).astype(np.float32)
+        for month in np.arange(12):
+            temp_array[month] = np.flipud(temp_array[month])
+
+        temp_array.tofile('flipped_nc_temperature.dat')
+
+        self._temperature = temp_array[
+            :,
+            self._nc_j0:self._nc_j1:self._nc_jskip,
+            self._nc_i0:self._nc_i1:self._nc_iskip]
 
         self.temperature_year = thisdate.year
 

--- a/cmip/examples/sample_cmip.cfg
+++ b/cmip/examples/sample_cmip.cfg
@@ -19,10 +19,10 @@ last_valid_year     | 2100                                | int      | last year
 # For cmip, the model knows it needs 'temperature' and 'precipitation' grids
 #grid_name           | temperature                         | string   | name of the model grid
 grid_type           | rectilinear                         | string   | form of the model grid
-grid_columns        | 40                                  | int      | number of columns in model grid (xdim)
+grid_columns        | 30                                  | int      | number of columns in model grid (xdim)
 grid_rows           | 23                                  | int      | number of rows in model grid (ydim)
 #  with temperature as np.zeros((grid_columns, grid_rows), dtype=np.float)
 i_ul                | 25                                  | int      | i-coord of upper left corner model domain
-j_ul                | 299                                 | int      | j-coord of upper left corner model domain
+j_ul                | 37                                  | int      | j-coord of upper left corner model domain
 #
 # Output

--- a/cmip/tests/test_bmi_cmip.py
+++ b/cmip/tests/test_bmi_cmip.py
@@ -5,6 +5,7 @@ test_bmi_cmip.py
 
 import datetime
 import os
+import numpy as np
 
 from nose.tools import assert_equal, assert_not_equal
 
@@ -74,7 +75,7 @@ def test_update_changes_temperature():
 
     b0.initialize(cfg_file=default_config_filename)
 
-    index_flat = 50
+    index_flat = 350
     index2D = (10, 5)
 
     Tb0_2d_0 = b0.get_value(

--- a/cmip/tests/test_cmip.py
+++ b/cmip/tests/test_cmip.py
@@ -3,12 +3,14 @@ test_cmip.py
   tests of the cmip component of permamodel
 """
 
+from __future__ import print_function
+
 import datetime
+import os
 import numpy as np
 from dateutil.relativedelta import relativedelta
 from nose.tools import assert_almost_equal, assert_equal, assert_true
 import cmip
-import os
 
 
 # ---------------------------------------------------
@@ -110,19 +112,19 @@ def test_specific_netcdf_values():
     ct = cmip.cmip_model.CMIPComponentMethod()
     ct.initialize_from_config_file()
 
-    # For Dec 1902, local grid (10, 13) is ncfile grid (45, 312)
+    # For Dec 1902, local grid (10, 13) is ncfile grid (35, 42)
     t_idx = 0
-    x_idx = 11
-    y_idx = 0
+    x_idx = 10
+    y_idx = 5
     # Temperature units for this model are Celsius
     assert_almost_equal(
-        ct._temperature[t_idx, y_idx, x_idx], 260.1971 - 273.15, places=2)
+        ct._temperature[t_idx, y_idx, x_idx], 251.0567 - 273.15, places=2)
 
     t_idx = 0
-    x_idx = 3
-    y_idx = 18
+    x_idx = 20
+    y_idx = 20
     assert_almost_equal(
-        ct._temperature[t_idx, y_idx, x_idx], 252.3327 - 273.15, places=2)
+        ct._temperature[t_idx, y_idx, x_idx], 254.7764 - 273.15, places=2)
 
 
 def test_getting_monthly_annual_temp_values():
@@ -131,17 +133,17 @@ def test_getting_monthly_annual_temp_values():
     ct = cmip.cmip_model.CMIPComponentMethod()
     ct.initialize_from_config_file()
 
-    x_idx = 2
-    y_idx = 1
+    x_idx = 7
+    y_idx = 7
     assert_almost_equal(ct.T_air_annual_mean[y_idx, x_idx],
-                        271.7334 - 273.15, places=2)
+                        264.155 - 273.15, places=2)
 
     t_idx = 6
     x_idx = 19
     y_idx = 3
-    jul_temperatures = ct.get_temperature_month_year(7, 1902)
+    jul_temperatures = ct.get_temperature_month_year(t_idx + 1, 1902)
     assert_almost_equal(jul_temperatures[y_idx, x_idx],
-                        287.3322 - 273.15, places=2)
+                        279.2897 - 273.15, places=2)
 
 
 def test_can_increment_to_end_of_run():
@@ -197,25 +199,26 @@ def test_can_get_subarray_for_date():
 
     # Configuration will set array bounds, and offset
     # Should assert the parameters here so as to check "correct" values
-
     temperature_array = ct.get_temperature_month_year(testdate.month,
-                                                       testdate.year)
+                                                      testdate.year)
+    assert_true(temperature_array is not None)
 
     # This should be from the 'testing' or 'examples' or 'data' directory?
     expected_temperature_array = \
-        np.fromfile(test_temp_field_file, dtype=np.float32)
+       np.fromfile(test_temp_field_file, dtype=np.float32)
+    assert_true(expected_temperature_array is not None)
 
 def test_temperature_units_are_Celsius():
     """ test that temperature values are not Kelvin """
     ct = cmip.cmip_model.CMIPComponentMethod()
     ct.initialize_from_config_file()
 
-    x_idx = 2
-    y_idx = 1
+    x_idx = 12
+    y_idx = 5
     assert_true(np.abs(ct.T_air_annual_mean[y_idx, x_idx]) < 50.0)
 
-    t_idx = 6
-    x_idx = 19
-    y_idx = 3
+    #t_idx = 6
+    x_idx = 21
+    y_idx = 13
     jul_temperatures = ct.get_temperature_month_year(7, 1902)
     assert_true(np.abs(jul_temperatures[y_idx, x_idx]) < 50.0)


### PR DESCRIPTION
Previously, the temperature array as-read from the netcdf file was flipped.

With this correction, the arrays are oriented in "image ordering" so that (0, 0) refers to the upper left corner.

The tests have been modified to reflect this, as has the sample_cmip.cfg file.